### PR TITLE
adding additional documentation, just adding back in color presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ When renaming the theme, rename the direcotry and search/replace the following.
 1. Search for `'_s'` (inside single quotations) to capture the text domain.
 2. Search for `_s_` to capture all the function names.
 3. Search for `Text Domain: _s` in `style.css`.
-4. Search for <code>&nbsp;_s</code> (with a space before it) to capture DocBlocks.
+4. Search for `<code>&nbsp;_s</code>` (with a space before it) to capture DocBlocks.
 5. Search for `_s-` to capture prefixed handles.
 6. Search for kanopi.
 7. Search for Kanopi.
@@ -35,7 +35,7 @@ NPM and Gulp
 ------------
 
 The site should Glob your JS and and SCSS together.
-Right now, if you add a new SCSS partial or an new JS file you may need to stop and restart Gulp or the NVM script. We are in the process of resolving this.
+Right now, if you add a new SCSS partial or an new JS file you may need to stop and restart Gulp, use `gulp build`, or the NVM script. We are in the process of resolving this.
 
 1. Run `npm install`.
 1. Run `npm run watch` to watch for changes. Alternatively run `gulp watch`.
@@ -45,3 +45,65 @@ Right now, if you add a new SCSS partial or an new JS file you may need to stop 
 Check our the gulp directory or the `package.json` file for more task to run.
 
 Good luck!
+
+
+About Using the Theme
+------------
+
+#### Breakpoints
+
+File: `sass/utilities/variables/_breakpoints.scss`
+
+Breakpoints are managed with an array of bears, because who doesn't love bears. If you need additional breakpoints, you can add them here with a custom name. Breakpoints should be applied to the selector they are controlling, rather than applying several different selectors to a breakpoint. Example:
+
+		div {
+			display: none;
+
+			@include breakpoint(bear(mama)) {
+				display: block;
+			}
+
+			a {
+				width: 100%;
+
+				@include breakpoint(bear(mama)) {
+					width: 50%;
+				}
+
+			}
+		}
+
+Breakpoints by default are "minimum width", meaning you should be building mobile first whenever possible. 
+
+
+#### Interpolation
+
+You can interpolate items for better responsive control over things like padding and font sizes. 
+
+In the following example, we can have the font-size at 30px on `bear(teen)` and lower, with `bear(grandpa)` and higher using 60px. In between, the font size will gradually increase and decrease with a percentage value.
+
+		div {
+			@include interpolate(font-size, bear(teen), bear(grandpa), 30px, 60px);
+		}
+
+
+In the following example, we can apply interpolate-many to multiple items to use the same values. In this case, the left and right padding would 10px on `bear(papa)` and gradually increase up to 50px at `bear(mama)`.
+
+		div {
+			@include interpolate-many(bear(papa), bear(mama), 10px, 50px, padding-right, padding-left);
+		}
+
+#### Color Presets
+
+File: `sass/utilities/variables/_colors.scss`
+
+You can add as many color presets as your theme needs, and even create new palettes.
+Use: `color: color-preset(black);` 
+
+#### Sass Lint, PHPCS, & Beautification
+
+You can set your IDE up to read the `.sass-lint.yml` file and alert you to errors against the theme standards. A beautifier can also be a helpful tool to keep your sass looking clean.
+
+This theme follows WordPress Core for PHP standards. The included `phpcs.xml.dist` file can be used with your IDE to do automatic code sniffing and beautificaiton.
+
+Kanopi expects their developers to imploy these standards. If you are a contractor and do not have your IDE configured to accommodate, please let your tech lead know.

--- a/sass/utilities/variables/_colors.scss
+++ b/sass/utilities/variables/_colors.scss
@@ -1,4 +1,11 @@
-$color__background-body: #ffffff;
+$white: #ffffff;
+$black: #000000;
+
+$color-presets: (white: $white,
+	black: $black,
+);
+
+$color__background-body: color-preset(white);
 $color__background-screen: #f1f1f1;
 $color__background-hr: #cccccc;
 $color__background-button: #e6e6e6;
@@ -9,7 +16,7 @@ $color__text-screen: #21759b;
 $color__text-input: #666666;
 $color__text-input-focus: #111111;
 $color__link: #ff7d55;
-$color__link-visited: #ff7d55;
+$color__link-visited: inherit;
 $color__link-hover: #ed6f49;
 $color__text-main: #404040;
 


### PR DESCRIPTION
## Description
> As a developer, I need to add some documentation that's 'newbie' friendly for those who are new to Kanopi / new to the theme.

Includes:
- documentation on some of the cooler functions
- documentation on coding standards
- added color-presets back 

## Affected URL
N/A


## Related Tickets

* [WP Vanilla Theme](https://kanopi.teamwork.com/#/tasks/26215610)


## Steps to Validate
1. Review code.
2. Review documentation

## Deploy Notes
Hey Shane, I was spitballing a bit here. I couldn't quite remember what we had talked about all them weeks ago, but I know we had thought the theme needed some basic how to use info. I also just added back in basic color presets because I have to go add them on every project anyway, might as well have them in the base theme.

If I'm wrong on any of this, please shout it out! I was going from my understanding and we all know how sideways my understanding can be sometimes. :D