### PR TITLE
Add uglify to Gulp JS config

### DIFF
--- a/gulp/tasks/js.js
+++ b/gulp/tasks/js.js
@@ -5,6 +5,7 @@
  ************************************************************/
 // Modules
 var del = require('del');
+var uglify = require('gulp-uglify');
 // Globals
 var gulp = global.gulp;
 var config = global.config;
@@ -21,6 +22,7 @@ const js_compile = function (done) {
     // .pipe(gulp.$.naturalSort())
     .pipe(gulp.$.sourcemaps.init())
     .pipe(gulp.$.concat('scripts.js'))
+    .pipe(uglify())
     .pipe(gulp.$.sourcemaps.write((config.js.sourceMapEmbed) ? null : './', {
       addComment: false,
     }))


### PR DESCRIPTION
## Description
> As a developer, I need to uglify the compiled JS.

UglifyJS was missing from the Gulp JS config (though it's already a dev dependency in package.json). This adds it to that config.

## Affected URL
n/a

## Related Tickets
n/a

## Steps to Validate
1. Download repo and `npm install`.
2. Run `gulp sass`.
3. Verify `dist/js/scripts.js` is uglified.
